### PR TITLE
Add speech recognition feature

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Chore (documentation, packages, or tests updates, nothing that affect the final user directly)
+- [ ] Release (new version of the application - only for production)
+
+## Description
+
+...
+
+## Screenshots
+
+...
+
+## Tasks
+
+- [task-id](task-link) or N/A
+
+## Checklist
+
+- [ ] My changes have less than or equal 400 lines
+- [ ] I have performed a self-review of my own code
+- [ ] The existing tests and linter pass locally with my changes
+- [ ] I have commented my code in hard-to-understand areas (if applicable)
+- [ ] I have created tests for my fix or feature (if applicable)
+
+## Dependencies
+
+This pull request has a dependency on the following others:
+
+- link-to-depency PR or N/A

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@rocketseat/eslint-config": "^2.2.2",
+    "@types/dom-speech-recognition": "^0.0.4",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ devDependencies:
   '@rocketseat/eslint-config':
     specifier: ^2.2.2
     version: 2.2.2(eslint@8.57.0)(typescript@5.4.2)
+  '@types/dom-speech-recognition':
+    specifier: ^0.0.4
+    version: 0.0.4
   '@types/node':
     specifier: ^20
     version: 20.11.25
@@ -880,6 +883,10 @@ packages:
     dependencies:
       tslib: 2.6.2
     dev: false
+
+  /@types/dom-speech-recognition@0.0.4:
+    resolution: {integrity: sha512-zf2GwV/G6TdaLwpLDcGTIkHnXf8JEf/viMux+khqKQKDa8/8BAUtXXZS563GnvJ4Fg0PBLGAaFf2GekEVSZ6GQ==}
+    dev: true
 
   /@types/json-schema@7.0.15:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}

--- a/src/app/(app)/(with-search)/note/[id]/page.tsx
+++ b/src/app/(app)/(with-search)/note/[id]/page.tsx
@@ -47,7 +47,7 @@ export default function NoteDetails({ params }: NoteDetailsProps) {
 
       <h2 className="py-8 text-2xl font-semibold text-strong">{note.title}</h2>
 
-      <div className="flex flex-col gap-2 leading-relaxed text-card-foreground">
+      <div className="leading-relaxed text-card-foreground">
         <ParsedContent text={note.content} />
       </div>
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
     <html lang="pt-BR" className={inter.variable} suppressHydrationWarning>
       <body className="antialiased transition-colors">
         <ThemeColorProvider>
-          <Toaster richColors position="top-right" />
+          <Toaster richColors position="top-right" closeButton />
           {children}
         </ThemeColorProvider>
       </body>

--- a/src/components/note-form/speech-to-text-dialog/index.tsx
+++ b/src/components/note-form/speech-to-text-dialog/index.tsx
@@ -1,0 +1,251 @@
+import * as Dialog from '@radix-ui/react-dialog'
+import * as VisuallyHidden from '@radix-ui/react-visually-hidden'
+import {
+  CircleCheck,
+  ClipboardCopy,
+  Copy,
+  Info,
+  Mic,
+  Paintbrush,
+  X,
+} from 'lucide-react'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+import { Popover } from '@/components/popover'
+import { Tooltip } from '@/components/tooltip'
+
+import { Input } from '../../input'
+import { Button } from '../../ui/button'
+import { useSpeechToText } from './useSpeechToText'
+
+interface SpeechToTextDialogProps extends Dialog.DialogContentProps {
+  onAddTranscriptionToNote: (transcription: string) => void
+}
+
+export function SpeechToTextDialog({
+  onAddTranscriptionToNote,
+  className,
+  ...props
+}: SpeechToTextDialogProps) {
+  const {
+    open,
+    setOpen,
+    transcription,
+    setTranscription,
+    isRecording,
+    handleRecording,
+    clipToClipboard,
+    handleAddTranscriptionToNote,
+    handleCancel,
+  } = useSpeechToText({
+    onAddTranscriptionToNote,
+  })
+  const [isClipboardSupported, setIsClipboardSupported] = useState(false)
+  const [openClearPopover, setOpenClearPopover] = useState(false)
+
+  const isActionsDisabled = !transcription.trim() || isRecording
+
+  function handleClearTranscription() {
+    setTranscription('')
+    setOpenClearPopover(false)
+  }
+
+  useEffect(() => {
+    setIsClipboardSupported('clipboard' in navigator)
+  }, [])
+
+  return (
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Trigger asChild>
+        <Button type="button" variant="outline" size="sm">
+          <Mic className="size-4 text-green-500" />
+          Transcrever gravação
+        </Button>
+      </Dialog.Trigger>
+
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-memonotes-950/90 backdrop-blur-sm dark:bg-zinc-950/90" />
+        <Dialog.Content
+          className={twMerge(
+            'fixed inset-0 flex w-full flex-col gap-8 overflow-y-auto bg-card p-8',
+            'sm:p-12',
+            'md:inset-auto md:left-1/2 md:top-1/2 md:h-[720px] md:max-h-[80vh] md:max-w-[720px] md:-translate-x-1/2 md:-translate-y-1/2',
+            'md:rounded-xl md:border md:border-border-soft md:shadow-md',
+            className,
+          )}
+          {...props}
+        >
+          <Dialog.Title className="flex gap-4 text-lg font-medium text-strong">
+            Transcreva sua gravação de voz
+            <Popover.Root>
+              <Popover.Trigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-fit p-1 text-muted-foreground"
+                >
+                  <Info strokeWidth={1.5} className="size-5" />
+                  <span className="sr-only">Excluir nota</span>
+                </Button>
+              </Popover.Trigger>
+              <Popover.Content className="flex max-w-[340px] flex-col gap-4 p-5 text-base">
+                <h6 className="font-semibold">Recomendações</h6>
+                <ul className="list-disc space-y-2 pl-5">
+                  <li>
+                    Inicie a gravação e aguarde pelo menos 2 segundos para
+                    falar;
+                  </li>
+                  <li>
+                    Fale próximo ao microfone, de forma clara e articulada para
+                    melhorar o reconhecimento das palavras.
+                  </li>
+                </ul>
+                <div className="h-px w-full bg-border-soft" />
+                <p className="text-sm">
+                  Alguns navegadores não são compatíveis com o reconhecimento de
+                  voz. Confira através{' '}
+                  <Link
+                    className="font-medium text-strong underline underline-offset-2 hover:text-accent-foreground"
+                    href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition#browser_compatibility"
+                  >
+                    deste link
+                  </Link>
+                  .
+                </p>
+              </Popover.Content>
+            </Popover.Root>
+          </Dialog.Title>
+
+          <VisuallyHidden.Root>
+            <Dialog.Description>
+              Inicie a gravação de voz e acompanhe abaixo a transcrição da sua
+              fala em tempo real.
+            </Dialog.Description>
+          </VisuallyHidden.Root>
+
+          <section className="flex flex-1 flex-col gap-4">
+            <Input.Root className="flex flex-1 flex-col gap-2">
+              <Input.Label className="text-sm">Conteúdo</Input.Label>
+              <Input.Wrapper className="flex-1">
+                <Input.Textarea
+                  value={transcription}
+                  onChange={(e) => setTranscription(e.target.value)}
+                  placeholder="Inicie a gravação clicando no botão abaixo"
+                  className="disabled:cursor-not-allowed"
+                  disabled={isRecording}
+                  required
+                />
+              </Input.Wrapper>
+            </Input.Root>
+
+            <div className="flex gap-2">
+              {isClipboardSupported && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  className="w-full whitespace-nowrap"
+                  disabled={isActionsDisabled}
+                  onClick={clipToClipboard}
+                >
+                  <Copy className="size-4" />
+                  Copiar
+                </Button>
+              )}
+
+              <Tooltip.Root>
+                <Tooltip.Trigger asChild>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    className="w-full whitespace-nowrap"
+                    disabled={isActionsDisabled}
+                    onClick={handleAddTranscriptionToNote}
+                  >
+                    <ClipboardCopy className="size-4" />
+                    Adicionar à nota
+                  </Button>
+                </Tooltip.Trigger>
+                <Tooltip.Content className="max-w-72 text-center">
+                  Se a nota já tiver conteúdo, a transcrição será adicionada no
+                  final.
+                </Tooltip.Content>
+              </Tooltip.Root>
+
+              <Popover.Root
+                open={openClearPopover}
+                onOpenChange={setOpenClearPopover}
+              >
+                <Popover.Trigger asChild>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    className="w-full whitespace-nowrap"
+                    disabled={isActionsDisabled}
+                  >
+                    <Paintbrush className="size-4" />
+                    Limpar
+                  </Button>
+                </Popover.Trigger>
+                <Popover.Content className="flex max-w-[240px] flex-col gap-4 p-6">
+                  <h6 className="font-semibold">
+                    Tem certeza que deseja limpar a transcrição?
+                  </h6>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="destructive"
+                    onClick={handleClearTranscription}
+                  >
+                    <CircleCheck className="size-4" />
+                    Confirmar
+                  </Button>
+                </Popover.Content>
+              </Popover.Root>
+            </div>
+          </section>
+
+          <section className="flex gap-4">
+            <Button
+              onClick={handleRecording}
+              type="button"
+              variant="outline"
+              className="w-full"
+              autoFocus
+            >
+              {isRecording ? (
+                <>
+                  <Mic className="size-5 animate-pulse text-red-500" />
+                  Parar gravação
+                </>
+              ) : (
+                <>
+                  <Mic className="size-5 text-green-500" />
+                  Iniciar gravação
+                </>
+              )}
+            </Button>
+            <Button onClick={handleCancel} type="button" variant="muted">
+              Cancelar
+            </Button>
+          </section>
+
+          <Dialog.Close asChild>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="absolute right-8 top-8 size-8 p-0 text-muted-foreground sm:right-4 sm:top-4"
+            >
+              <X className="size-6 sm:size-5" />
+              <span className="sr-only">Fechar</span>
+            </Button>
+          </Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/src/components/note-form/speech-to-text-dialog/useSpeechToText.ts
+++ b/src/components/note-form/speech-to-text-dialog/useSpeechToText.ts
@@ -1,0 +1,110 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+let speechRecognition: SpeechRecognition | null = null
+
+interface useSpeechToTextProps {
+  onAddTranscriptionToNote: (transcription: string) => void
+}
+
+export function useSpeechToText({
+  onAddTranscriptionToNote,
+}: useSpeechToTextProps) {
+  const [open, setOpen] = useState(false)
+  const [transcription, setTranscription] = useState('')
+  const [isRecording, setIsRecording] = useState(false)
+
+  const isActionsDisabled = !transcription.trim() || isRecording
+
+  async function clipToClipboard() {
+    if (isActionsDisabled) return
+
+    try {
+      await navigator.clipboard.writeText(transcription)
+      toast.success('A transcrição foi copiada para sua área de transferência.')
+    } catch (error) {
+      console.error(error)
+      toast.error('Não foi possível copiar o texto.')
+    }
+  }
+
+  function handleAddTranscriptionToNote() {
+    onAddTranscriptionToNote(transcription.trim())
+    setTranscription('')
+    setOpen(false)
+    toast.success('Transcrição adicionada à nota com sucesso!')
+  }
+
+  function handleRecording() {
+    isRecording ? stopRecording() : startRecording()
+  }
+
+  function startRecording() {
+    const isSpeechRecognitionAPIAvailable =
+      'SpeechRecognition' in window || 'webkitSpeechRecognition' in window
+
+    if (!isSpeechRecognitionAPIAvailable) {
+      return toast.error(
+        'Este navegador não tem suporte ao reconhecimento de fala.',
+      )
+    }
+
+    const SpeechRecognitionAPI =
+      window.SpeechRecognition || window.webkitSpeechRecognition
+    speechRecognition = new SpeechRecognitionAPI()
+    speechRecognition.lang = 'pt-BR'
+    speechRecognition.continuous = true
+    speechRecognition.interimResults = true
+    speechRecognition.maxAlternatives = 1
+
+    speechRecognition.onresult = (event) => {
+      const transcribed = Array.from(event.results).reduce((text, result) => {
+        return text.concat(result[0].transcript)
+      }, '')
+
+      const previousContent = transcription.trim()
+      previousContent
+        ? setTranscription(`${transcription}\n\n${transcribed}`)
+        : setTranscription(transcribed)
+    }
+
+    speechRecognition.onerror = (event) => {
+      console.error(event)
+      setIsRecording(false)
+
+      if (event.error === 'no-speech') {
+        return toast.error(
+          'Nenhuma fala foi detectada. Por favor, inicie a gravação novamente.',
+        )
+      }
+
+      handleCancel()
+      toast.error('Este navegador não tem suporte ao reconhecimento de fala.')
+    }
+
+    speechRecognition.start()
+    setIsRecording(true)
+  }
+
+  function stopRecording() {
+    speechRecognition?.stop()
+    setIsRecording(false)
+  }
+
+  function handleCancel() {
+    setTranscription('')
+    setOpen(false)
+  }
+
+  return {
+    open,
+    setOpen,
+    transcription,
+    setTranscription,
+    isRecording,
+    clipToClipboard,
+    handleAddTranscriptionToNote,
+    handleRecording,
+    handleCancel,
+  }
+}

--- a/src/components/note-form/useNoteForm.ts
+++ b/src/components/note-form/useNoteForm.ts
@@ -1,0 +1,105 @@
+import { useRouter } from 'next/navigation'
+import { FormEvent, useState } from 'react'
+import { toast } from 'sonner'
+
+import { INote, useStore } from '@/app/store'
+
+interface UseNoteFormProps {
+  note?: INote
+}
+
+export function useNoteForm({ note }: UseNoteFormProps) {
+  const [title, setTitle] = useState('')
+  const [content, setContent] = useState('')
+  const [tagsInString, setTagsInString] = useState('')
+  const [isSpeechRecognitionAPIAvailable, setIsSpeechRecognitionAPIAvailable] =
+    useState(false)
+  const router = useRouter()
+  const { isPending, addNote, updateNote, fetchNotes } = useStore((store) => {
+    return {
+      isPending: store.isPending,
+      addNote: store.addNote,
+      updateNote: store.updateNote,
+      fetchNotes: store.fetchNotes,
+    }
+  })
+
+  const isSubmitDisabled = !title.trim() || !content.trim()
+
+  function addTranscriptionToNote(transcription: string) {
+    const previousContent = content.trim()
+    previousContent
+      ? setContent(`${content}\n\n${transcription}`)
+      : setContent(transcription)
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    if (isSubmitDisabled) {
+      return toast.warning('Não é possível adicionar uma nota vazia!')
+    }
+
+    let tags: string[] = []
+
+    if (tagsInString.length > 0) {
+      tags = Array.from(new Set(tagsInString.split(/\s+/)))
+      const shortTag = tags.find((tag) => tag.length < 3)
+
+      if (shortTag) {
+        return toast.warning('Cada Tag deve conter 3 ou mais letras.')
+      }
+    }
+
+    note
+      ? await updateNote({
+          id: note.id,
+          title: title.trim(),
+          content: content.trim(),
+          tags,
+        })
+          .then(() => {
+            toast.success('Nota atualizada com sucesso!')
+            router.back()
+            fetchNotes()
+          })
+          .catch(() => {
+            toast.error('Ops, algo deu errado!')
+          })
+      : await addNote({ title: title.trim(), content: content.trim(), tags })
+          .then(() => {
+            toast.success('Nota adicionada com sucesso!')
+            setTitle('')
+            setContent('')
+            setTagsInString('')
+            router.push('/')
+            fetchNotes()
+          })
+          .catch(() => {
+            toast.error('Ops, algo deu errado!')
+          })
+  }
+
+  function handleCancel() {
+    setTitle('')
+    setContent('')
+    setTagsInString('')
+    router.back()
+  }
+
+  return {
+    title,
+    setTitle,
+    content,
+    setContent,
+    tagsInString,
+    setTagsInString,
+    isSpeechRecognitionAPIAvailable,
+    setIsSpeechRecognitionAPIAvailable,
+    addTranscriptionToNote,
+    isSubmitDisabled,
+    handleSubmit,
+    isPending,
+    handleCancel,
+  }
+}

--- a/src/components/parse-content.tsx
+++ b/src/components/parse-content.tsx
@@ -3,5 +3,9 @@ interface ParsedContentProps {
 }
 
 export function ParsedContent({ text }: ParsedContentProps) {
-  return text.split('\n').map((line, i) => <p key={i}>{line}</p>)
+  return text.split('\n').map((line, i) => (
+    <p key={i} className="pb-4">
+      {line}
+    </p>
+  ))
 }

--- a/src/components/popover/content.tsx
+++ b/src/components/popover/content.tsx
@@ -16,7 +16,7 @@ export function Content({ children, className, ...props }: ContentProps) {
         sideOffset={4}
         side="top"
         className={twMerge(
-          'rounded-md bg-background p-3 text-sm shadow-lg ring-1 ring-border-soft',
+          'rounded-md bg-background p-4 text-sm shadow-lg ring-1 ring-border-soft',
           className,
         )}
         {...props}

--- a/src/components/popover/root.tsx
+++ b/src/components/popover/root.tsx
@@ -1,9 +1,9 @@
 import * as RadixPopover from '@radix-ui/react-popover'
 import { ReactNode } from 'react'
 
-interface RootProps {
+interface RootProps extends RadixPopover.PopoverProps {
   children: ReactNode
 }
-export function Root({ children }: RootProps) {
-  return <RadixPopover.Root>{children}</RadixPopover.Root>
+export function Root({ children, ...props }: RootProps) {
+  return <RadixPopover.Root {...props}>{children}</RadixPopover.Root>
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { ComponentProps, forwardRef } from 'react'
 import { cn } from '@/utils/class-name-merge'
 
 const buttonVariants = cva(
-  'flex items-center justify-center rounded-md font-medium leading-none outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed',
+  'flex items-center justify-center rounded-md font-medium leading-none outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {

--- a/src/utils/get-excerpt.ts
+++ b/src/utils/get-excerpt.ts
@@ -1,4 +1,4 @@
-export function getExcerpt(text: string, length: number = 160) {
+export function getExcerpt(text: string, length: number = 120) {
   if (text.length <= length) return text
   return text.substring(0, length).concat('...')
 }


### PR DESCRIPTION
## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Description

This adds the speech-to-text feature to form that adds/updates notes. And also updates note-form structure, separating it in react components and hooks, to make it easier to read and do maintenance.

It was used Speech Recognition Web API to record user audio and transcribe it in real-time. This feature is available on a dialog that shows only in browsers that supports the API. In case browsers support it partially, an error message is showed and the recording is canceled if something went wrong.

The user is able to:
 - change the transcription after is stopped;
 - copy it to clipboard;
 - add to the note, if note already has content, the transcription will be placed at the and;
 - clear the transcription and repeat.

## Screenshots

![add-note-form](https://github.com/julianosill/memonotes/assets/8575672/28ef70e1-f0fd-4afa-ab14-f73f6ab78225)
![transcribe-dialog](https://github.com/julianosill/memonotes/assets/8575672/7e1035a3-8204-42be-8dc4-87b457d3a541)

## Checklist

- [x] I have performed a self-review of my own code
- [x] The existing linter pass locally with my changes

## Dependencies

This pull request has no external dependencies.